### PR TITLE
fix: keycloak url fix

### DIFF
--- a/keycloak/src/retrieval.rs
+++ b/keycloak/src/retrieval.rs
@@ -32,7 +32,7 @@ pub async fn retrieve_keycloak_token(
     client: &Client,
     keycloak_config: KeycloakConfig,
 ) -> Result<KeycloakToken> {
-    let keycloak_admin_url = keycloak_config.url;
+    let keycloak_admin_url = format!("{}/auth/realms/flexys/protocol/openid-connect/token", keycloak_config.url);
 
     info!(
         "Retrieving keycloak token from endpoint: {}",


### PR DESCRIPTION
include the pah suffix because keycloak_url only contains the base url